### PR TITLE
revert attempted fix to 426 err, it was a netlify problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     },
     "dependencies": {
         "react": "^17.0.2",
-        "react-dom": "^17.0.2",
-        "cross-fetch": "^3.1.4"
+        "react-dom": "^17.0.2"
     }
 }

--- a/src/services/newsAPI.js
+++ b/src/services/newsAPI.js
@@ -1,6 +1,5 @@
 const key = process.env.REACT_APP_API_KEY;
 const domain = 'hackaday.com';
-import fetch from 'cross-fetch';
 // eslint-disable-next-line max-len
 const URL = `https://newsapi.org/v2/everything?domains=${domain}&apiKey=${key}`;
 


### PR DESCRIPTION
It turns out the 426 response code I was getting from the newsAPI with my deployed Netlify site was happening because Netlify doesn't allow cors on the free plan. The 426 response code was very misleading and threw me off for a while. I mean sure, 'Upgrade' applies in a way because I'd need to upgrade my Netlify account to use cors. Very funny, Netlify.